### PR TITLE
Using dplyr::bind_rows() instead of dplyr::rbind_all()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Identification and Assessment of Single Nucleotide Variants through Shift
 Version: 1.7.1
 Author: Julian Gehring, Simon Anders, Bernd Klaus (EMBL Heidelberg)
 Maintainer: Julian Gehring <julian.gehring@embl.de>
-Imports: methods, S4Vectors (>= 0.9.25), IRanges, GenomeInfoDb, ggbio, ggplot2, exomeCopy, SomaticSignatures, Rsamtools, shiny, VGAM, dplyr, reshape2
+Imports: methods, S4Vectors (>= 0.9.25), IRanges, GenomeInfoDb, ggbio, ggplot2, exomeCopy, SomaticSignatures, Rsamtools, shiny, VGAM, dplyr (>= 0.5.0), reshape2
 Depends: R (>= 3.0.2), GenomicRanges, VariantAnnotation
 Suggests: h5vcData, testthat, knitr, optparse, BSgenome.Hsapiens.UCSC.hg19
 Description: The 'Rariant' package identifies single nucleotide variants from sequencing data based on the difference of binomially distributed mismatch rates between matched samples.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,7 +12,7 @@ importFrom(VariantAnnotation, VRanges)
 importFrom(exomeCopy, subdivideGRanges)
 importFrom(SomaticSignatures, seqchar)
 importFrom(VGAM, logit)
-importFrom(dplyr, rbind_all)
+importFrom(dplyr, bind_rows)
 importFrom(reshape2, melt)
 
 export(acCi, nhsCi)

--- a/R/rariantFromBam.R
+++ b/R/rariantFromBam.R
@@ -47,7 +47,7 @@ rariantFromBam <- function(test, control, region, beta = 0.95, alpha = 1 - beta,
     
     res = NULL ## must be set
     if(value & length(val) > 0) {
-        res = rbind_all(val) ## or unlist on a GRL
+        res = bind_rows(val) ## or unlist on a GRL
         #if(!is.null(res)) { ## TODO: needed?
         res = df2gr(res)
         #}


### PR DESCRIPTION
We're https://github.com/tidyverse/dplyr/issues/4579 in the process of releasing dplyr 0.8.4 and this package fail at our reverse dependency checks because the `dplyr::rbind_all()` function has been formally removed after being deprecated for many versions. 

We might revert that decision because it affects a handful of packages, but in any case even if `rbind_all()` stays a little longer, you still should use `bind_rows()` instead. 

````
* installing *source* package ‘Rariant’ ...
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
Warning messages:
1: package ‘GenomicRanges’ was built under R version 3.6.1
2: package ‘S4Vectors’ was built under R version 3.6.1
3: package ‘IRanges’ was built under R version 3.6.1
4: package ‘SummarizedExperiment’ was built under R version 3.6.1
5: package ‘BiocParallel’ was built under R version 3.6.1
6: package ‘Rsamtools’ was built under R version 3.6.1
Error: object 'rbind_all' is not exported by 'namespace:dplyr'
Execution halted
````